### PR TITLE
add exception for text in scan_id

### DIFF
--- a/gemviz/bluesky_runs_catalog_search.py
+++ b/gemviz/bluesky_runs_catalog_search.py
@@ -77,8 +77,10 @@ class BRCSearchPanel(QtWidgets.QWidget):
             try:
                 cat = utils.get_tiled_runs(cat, scan_id=int(scan_id))
             except ValueError:
+                self.setStatus('Invalid entry: scan_id must be an integer.')
                 pass
-                # TODO: after updating tiled is updated, we should try this:
+                # TODO: Issue #145 https://github.com/BCDA-APS/gemviz/pull/145
+                # after updating tiled is updated (issue #53), we should try this:
                 # import tiled.catalogs
                 # empty_catalog = tiled.catalogs.Catalog.from_dict({})
                 # return empty_catalog

--- a/gemviz/bluesky_runs_catalog_search.py
+++ b/gemviz/bluesky_runs_catalog_search.py
@@ -79,7 +79,7 @@ class BRCSearchPanel(QtWidgets.QWidget):
             except ValueError:
                 self.setStatus('Invalid entry: scan_id must be an integer.')
                 pass
-                # TODO: Issue #145 https://github.com/BCDA-APS/gemviz/pull/145
+                # TODO: PR #145 https://github.com/BCDA-APS/gemviz/pull/145
                 # after updating tiled is updated (issue #53), we should try this:
                 # import tiled.catalogs
                 # empty_catalog = tiled.catalogs.Catalog.from_dict({})

--- a/gemviz/bluesky_runs_catalog_search.py
+++ b/gemviz/bluesky_runs_catalog_search.py
@@ -60,7 +60,7 @@ class BRCSearchPanel(QtWidgets.QWidget):
 
     def filteredCatalog(self):
         import tiled.queries
-
+        
         cat = self.catalog()
 
         since = self.date_time_widget.low()
@@ -74,7 +74,14 @@ class BRCSearchPanel(QtWidgets.QWidget):
 
         scan_id = self.scan_id.text().strip()
         if len(scan_id) > 0:
-            cat = utils.get_tiled_runs(cat, scan_id=int(scan_id))
+            try:
+                cat = utils.get_tiled_runs(cat, scan_id=int(scan_id))
+            except ValueError:
+                pass
+                # TODO: after updating tiled is updated, we should try this:
+                # import tiled.catalogs
+                # empty_catalog = tiled.catalogs.Catalog.from_dict({})
+                # return empty_catalog
 
         motors = self.positioners.text().strip()
         if len(motors) > 0:


### PR DESCRIPTION
- close #129

The behavior that would make the most sense to me if some text is entered would be to return an empty catalog (anything else triggers a lot of error since a catalog is expected to be returned). That would clear the tableview, clearly showing that the user did something wrong. I found this:

``` python
from tiled.catalogs import Catalog
empty_catalog = Catalog.from_dict({})
```
but I think our version of tiled is too old:

```python
In [1]: import tiled

In [2]: print(tiled.__version__)
0.1.0a89

In [3]: import tiled.catalogs
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[3], line 1
----> 1 import tiled.catalogs

ModuleNotFoundError: No module named 'tiled.catalogs'
```