### PR TITLE
pin python version to <3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,7 @@
 [build-system]
-# qt ==5
-# pyqt ==5
 requires = [
-  "pyRestTable",
-  "setuptools>=61.0",
-  "setuptools_scm[toml]>=6.2",
-  "tiled"
+  "setuptools>=64",
+  "setuptools_scm[toml]>=8",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -23,7 +19,7 @@ maintainers = [
 ]
 dynamic = ["version"]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8, <3.12"
 keywords = ["bluesky", "databroker", "tiled", "catalog"]
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/?highlight=license
 license = {file = "gemviz/LICENSE"}
@@ -49,6 +45,14 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Scientific/Engineering",
     "Topic :: Utilities",
+]
+
+# qt ==5
+# pyqt ==5
+dependencies = [
+  "pyqtgraph",
+  "pyRestTable",
+  "tiled",
 ]
 
 [project.urls]


### PR DESCRIPTION
- close #182

tiled is [not ready](https://github.com/bluesky/tiled/blob/3b5455c5515a9bc56999faaaba4f4bb4b65efd37/.github/workflows/ci.yml#L28-L31) for Py 3.12 yet:

```yaml
        - "3.8"
        - "3.9"
        - "3.10"
        - "3.11"
```